### PR TITLE
Amend gitignore to ignore .pyc files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.pyc
 .vscode
 test.ipynb
 tests.ipynb


### PR DESCRIPTION
Lots of  .pyc files are generated from the application.

<img width="782" alt="Screenshot 2025-06-30 at 16 24 15" src="https://github.com/user-attachments/assets/87967dcc-11ed-4012-a328-8939a2107e56" />

Added functionality to ignore them.